### PR TITLE
Closes #81 Optim: Parallelize GATK wrapper to alleviate single-thread bottleneck

### DIFF
--- a/__frag8/TwinPrimeTest.java
+++ b/__frag8/TwinPrimeTest.java
@@ -1,0 +1,60 @@
+package com.thealgorithms.maths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class TwinPrimeTest {
+
+    @Test
+    void shouldReturn7() {
+        // given
+        int number = 5;
+        int expectedResult = 7;
+
+        // when
+        int actualResult = TwinPrime.getTwinPrime(number);
+
+        // then
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    void shouldReturn5() {
+        // given
+        int number = 3;
+        int expectedResult = 5;
+
+        // when
+        int actualResult = TwinPrime.getTwinPrime(number);
+
+        // then
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    void shouldReturnNegative1() {
+        // given
+        int number = 4;
+        int expectedResult = -1;
+
+        // when
+        int actualResult = TwinPrime.getTwinPrime(number);
+
+        // then
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    void shouldReturn19() {
+        // given
+        int number = 17;
+        int expectedResult = 19;
+
+        // when
+        int actualResult = TwinPrime.getTwinPrime(number);
+
+        // then
+        assertEquals(expectedResult, actualResult);
+    }
+}

--- a/__frag8/rot13.go
+++ b/__frag8/rot13.go
@@ -1,0 +1,16 @@
+// Package rot13 is a simple letter substitution cipher that replaces a letter with the 13th letter after it in the alphabet.
+// description: ROT13
+// details: ROT13 is a simple letter substitution cipher that replaces a letter with the 13th letter after it in the alphabet. it is a special case of the Caesar cipher
+// time complexity: O(n)
+// space complexity: O(n)
+// ref: https://en.wikipedia.org/wiki/ROT13
+package rot13
+
+import (
+	"github.com/TheAlgorithms/Go/cipher/caesar"
+)
+
+// rot13 is a special case, which is fixed the shift of 13, of the Caesar cipher
+func rot13(input string) string {
+	return caesar.Encrypt(input, 13)
+}


### PR DESCRIPTION
81 Closing the bug report due to a lack of minimal reproducible sequence data or logs. Without the specific FASTQ headers causing the failure, we cannot verify the claimed regression in the sequence-masker. The user is welcome to re-open once the necessary diagnostic information is provided.