### PR TITLE
Closes #86 Fix spelling errors in documentation

### DIFF
--- a/__run_src1/IsPowerofFour.js
+++ b/__run_src1/IsPowerofFour.js
@@ -1,0 +1,17 @@
+/**
+ * @author : dev-madhurendra
+ * Checks whether the given number is a power of four or not.
+ *
+ * A number is considered a power of four if and only if there is a single '1' bit in its binary representation,
+ * and that '1' bit is at the first position, followed by an even number of '0' bits.
+ *
+ * @param {number} n - The input number to check.
+ * @returns {boolean} True if the number is a power of four, false otherwise.
+ *
+ * @example
+ * const result = isPowerOfFour(16); // Returns true (16 is 4^2)
+ * const result2 = isPowerOfFour(5);  // Returns false (5 is not a power of four)
+ */
+const isPowerOfFour = (n) => n > 0 && (n & (n - 1)) === 0 && n % 3 === 1
+
+export { isPowerOfFour }

--- a/__run_src1/Problem3.hs
+++ b/__run_src1/Problem3.hs
@@ -1,0 +1,9 @@
+module ProjectEuler.Problem3.Problem3 where
+
+largestPrimeFactor :: Integer -> Integer -> Integer 
+largestPrimeFactor divi val 
+  | val `mod` divi == 0 = if divi == val then val else largestPrimeFactor 2 $ val `div` divi
+  | val `mod` divi /= 0 = largestPrimeFactor (divi + 1) val
+
+main = do
+  print $ largestPrimeFactor 2 600851475143

--- a/__run_src1/selection_sort_test.exs
+++ b/__run_src1/selection_sort_test.exs
@@ -1,0 +1,33 @@
+defmodule Algorithms.Sorting.SelectionSortTest do
+  alias Algorithms.Sorting.SelectionSort
+
+  use ExUnit.Case
+
+  describe "select_sort/1 - Test cases" do
+    test "test 1" do
+      inp = [7, 1]
+      outp = [1, 7]
+      assert SelectionSort.selection_sort(inp) === outp
+    end
+
+    test "test 2" do
+      inp = [2, 1, 5, 4, 3]
+      outp = [1, 2, 3, 4, 5]
+      assert SelectionSort.selection_sort(inp) === outp
+    end
+
+    test "test 3" do
+      inp = [1, 8, 3, 6, 5, 4, 7, 2, 9, 0]
+      outp = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+      assert SelectionSort.selection_sort(inp) === outp
+    end
+
+    test "test 4" do
+      inp = [12, 34, 23, 44, 1, 10, 18, 85]
+      outp = [1, 10, 12, 18, 23, 34, 44, 85]
+
+      assert SelectionSort.selection_sort(inp) === outp
+    end
+  end
+end


### PR DESCRIPTION
86 This edge case affecting only Python 3.7 will not be addressed since that version reached end-of-life. Our resources are better spent supporting current and future Python versions that the majority of our user base employs.