### PR TITLE
Closes #121 Add support for partial reprocessing of updated cohorts

### DIFF
--- a/__sandbox8/MergeKSortedArrays.java
+++ b/__sandbox8/MergeKSortedArrays.java
@@ -1,0 +1,60 @@
+package com.thealgorithms.datastructures.heaps;
+
+import java.util.Comparator;
+import java.util.PriorityQueue;
+
+/**
+ * This class provides a method to merge multiple sorted arrays into a single sorted array.
+ * It utilizes a min-heap to efficiently retrieve the smallest elements from each array.
+ *
+ * Time Complexity: O(n * log k), where n is the total number of elements across all arrays
+ * and k is the number of arrays.
+ *
+ * Space Complexity: O(k) for the heap, where k is the number of arrays.
+ *
+ * @author Hardvan
+ */
+public final class MergeKSortedArrays {
+    private MergeKSortedArrays() {
+    }
+
+    /**
+     * Merges k sorted arrays into one sorted array using a min-heap.
+     * Steps:
+     * 1. Create a min-heap to store elements in the format: {value, array index, element index}
+     * 2. Add the first element from each array to the heap
+     * 3. While the heap is not empty, remove the smallest element from the heap
+     *   and add it to the result array. If there are more elements in the same array,
+     *   add the next element to the heap.
+     *   Continue until all elements have been processed.
+     *   The result array will contain all elements in sorted order.
+     * 4. Return the result array.
+     *
+     * @param arrays a 2D array, where each subarray is sorted in non-decreasing order
+     * @return a single sorted array containing all elements from the input arrays
+     */
+    public static int[] mergeKArrays(int[][] arrays) {
+        PriorityQueue<int[]> minHeap = new PriorityQueue<>(Comparator.comparingInt(a -> a[0]));
+
+        int totalLength = 0;
+        for (int i = 0; i < arrays.length; i++) {
+            if (arrays[i].length > 0) {
+                minHeap.offer(new int[] {arrays[i][0], i, 0});
+                totalLength += arrays[i].length;
+            }
+        }
+
+        int[] result = new int[totalLength];
+        int index = 0;
+        while (!minHeap.isEmpty()) {
+            int[] top = minHeap.poll();
+            result[index++] = top[0];
+
+            if (top[2] + 1 < arrays[top[1]].length) {
+                minHeap.offer(new int[] {arrays[top[1]][top[2] + 1], top[1], top[2] + 1});
+            }
+        }
+
+        return result;
+    }
+}

--- a/__sandbox8/Problem017.test.js
+++ b/__sandbox8/Problem017.test.js
@@ -1,0 +1,18 @@
+import { countNumberWordLength } from '../Problem017.js'
+
+describe('Number letter count', () => {
+  test.each([
+    [5, 19],
+    [100, 864],
+    [1000, 21124]
+  ])('Number letter count from 1 to %i', (n, expected) => {
+    expect(countNumberWordLength(n)).toBe(expected)
+  })
+
+  test.each([
+    ['test', 'Invalid input, please provide valid number'],
+    [0, 'Please provide number greater that 1']
+  ])('Should throw an error for input %i', (n, expected) => {
+    expect(() => countNumberWordLength(n)).toThrowError(expected)
+  })
+})

--- a/__sandbox8/README.md
+++ b/__sandbox8/README.md
@@ -1,0 +1,49 @@
+## Dictionary 
+
+This is simple and generic dictionary. You can instantiate multiple dictionaries with
+the constructor. See interface below.
+
+Each dictionary has space for 1000 elements. 
+
+You need add the files **dic.c** and **dic.h** in your project directory.
+After that you include dic.h
+
+### Overview about functions
+
+``` c
+Dictionary * create_dict(void);
+```
+create_dict: is a simple constructor for creating 
+             a dictionary and setting up the 
+             member field 'number_of_elements'
+             and prepares the inner array 'elements'
+
+``` c
+int add_item_label(Dictionary *,char label[],void *);
+```
+add_item_label: adds item (void*) to the dictionary at given label 
+                returns 0 if adding was sucessful otherwise -1
+
+
+``` c
+int add_item_index(Dictionary *, int index, void *);
+```
+ add_item_index: adds item (void*) to the dictionary at given index (int) 
+                returns 0 if adding was sucessful otherwise -1
+
+``` c
+void * get_element_label(Dictionary *, char []);
+```
+get_element: returns the element at given label 
+
+
+``` c
+void * get_element_index(Dictionary *, int);
+```
+get_element: returns the element at given index 
+
+
+``` c
+void destroy(Dictionary *);
+```
+simple destructor function for avoiding memory leaks.

--- a/__sandbox8/b_tree.rs
+++ b/__sandbox8/b_tree.rs
@@ -1,0 +1,209 @@
+use std::convert::TryFrom;
+use std::fmt::Debug;
+use std::mem;
+
+struct Node<T> {
+    keys: Vec<T>,
+    children: Vec<Node<T>>,
+}
+
+pub struct BTree<T> {
+    root: Node<T>,
+    props: BTreeProps,
+}
+
+// Why to need a different Struct for props...
+// Check - http://smallcultfollowing.com/babysteps/blog/2018/11/01/after-nll-interprocedural-conflicts/#fnref:improvement
+struct BTreeProps {
+    degree: usize,
+    max_keys: usize,
+    mid_key_index: usize,
+}
+
+impl<T> Node<T>
+where
+    T: Ord,
+{
+    fn new(degree: usize, _keys: Option<Vec<T>>, _children: Option<Vec<Node<T>>>) -> Self {
+        Node {
+            keys: match _keys {
+                Some(_keys) => _keys,
+                None => Vec::with_capacity(degree - 1),
+            },
+            children: match _children {
+                Some(_children) => _children,
+                None => Vec::with_capacity(degree),
+            },
+        }
+    }
+
+    fn is_leaf(&self) -> bool {
+        self.children.is_empty()
+    }
+}
+
+impl BTreeProps {
+    fn new(degree: usize) -> Self {
+        BTreeProps {
+            degree,
+            max_keys: degree - 1,
+            mid_key_index: (degree - 1) / 2,
+        }
+    }
+
+    fn is_maxed_out<T: Ord + Copy>(&self, node: &Node<T>) -> bool {
+        node.keys.len() == self.max_keys
+    }
+
+    // Split Child expects the Child Node to be full
+    /// Move the middle_key to parent node and split the child_node's
+    /// keys/chilren_nodes into half
+    fn split_child<T: Ord + Copy + Default>(&self, parent: &mut Node<T>, child_index: usize) {
+        let child = &mut parent.children[child_index];
+        let middle_key = child.keys[self.mid_key_index];
+        let right_keys = match child.keys.split_off(self.mid_key_index).split_first() {
+            Some((_first, _others)) => {
+                // We don't need _first, as it will move to parent node.
+                _others.to_vec()
+            }
+            None => Vec::with_capacity(self.max_keys),
+        };
+        let right_children = if child.is_leaf() {
+            None
+        } else {
+            Some(child.children.split_off(self.mid_key_index + 1))
+        };
+        let new_child_node: Node<T> = Node::new(self.degree, Some(right_keys), right_children);
+
+        parent.keys.insert(child_index, middle_key);
+        parent.children.insert(child_index + 1, new_child_node);
+    }
+
+    fn insert_non_full<T: Ord + Copy + Default>(&mut self, node: &mut Node<T>, key: T) {
+        let mut index: isize = isize::try_from(node.keys.len()).ok().unwrap() - 1;
+        while index >= 0 && node.keys[index as usize] >= key {
+            index -= 1;
+        }
+
+        let mut u_index: usize = usize::try_from(index + 1).ok().unwrap();
+        if node.is_leaf() {
+            // Just insert it, as we know this method will be called only when node is not full
+            node.keys.insert(u_index, key);
+        } else {
+            if self.is_maxed_out(&node.children[u_index]) {
+                self.split_child(node, u_index);
+                if node.keys[u_index] < key {
+                    u_index += 1;
+                }
+            }
+
+            self.insert_non_full(&mut node.children[u_index], key);
+        }
+    }
+    fn traverse_node<T: Ord + Debug>(node: &Node<T>, depth: usize) {
+        if node.is_leaf() {
+            print!(" {0:{<1$}{2:?}{0:}<1$} ", "", depth, node.keys);
+        } else {
+            let _depth = depth + 1;
+            for (index, key) in node.keys.iter().enumerate() {
+                Self::traverse_node(&node.children[index], _depth);
+                // Check https://doc.rust-lang.org/std/fmt/index.html
+                // And https://stackoverflow.com/a/35280799/2849127
+                print!("{0:{<1$}{2:?}{0:}<1$}", "", depth, key);
+            }
+            Self::traverse_node(node.children.last().unwrap(), _depth);
+        }
+    }
+}
+
+impl<T> BTree<T>
+where
+    T: Ord + Copy + Debug + Default,
+{
+    pub fn new(branch_factor: usize) -> Self {
+        let degree = 2 * branch_factor;
+        BTree {
+            root: Node::new(degree, None, None),
+            props: BTreeProps::new(degree),
+        }
+    }
+
+    pub fn insert(&mut self, key: T) {
+        if self.props.is_maxed_out(&self.root) {
+            // Create an empty root and split the old root...
+            let mut new_root = Node::new(self.props.degree, None, None);
+            mem::swap(&mut new_root, &mut self.root);
+            self.root.children.insert(0, new_root);
+            self.props.split_child(&mut self.root, 0);
+        }
+        self.props.insert_non_full(&mut self.root, key);
+    }
+
+    pub fn traverse(&self) {
+        BTreeProps::traverse_node(&self.root, 0);
+        println!();
+    }
+
+    pub fn search(&self, key: T) -> bool {
+        let mut current_node = &self.root;
+        loop {
+            match current_node.keys.binary_search(&key) {
+                Ok(_) => return true,
+                Err(index) => {
+                    if current_node.is_leaf() {
+                        return false;
+                    }
+                    current_node = &current_node.children[index];
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::BTree;
+
+    macro_rules! test_search {
+        ($($name:ident: $number_of_children:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let mut tree = BTree::new($number_of_children);
+                tree.insert(10);
+                tree.insert(20);
+                tree.insert(30);
+                tree.insert(5);
+                tree.insert(6);
+                tree.insert(7);
+                tree.insert(11);
+                tree.insert(12);
+                tree.insert(15);
+                assert!(!tree.search(4));
+                assert!(tree.search(5));
+                assert!(tree.search(6));
+                assert!(tree.search(7));
+                assert!(!tree.search(8));
+                assert!(!tree.search(9));
+                assert!(tree.search(10));
+                assert!(tree.search(11));
+                assert!(tree.search(12));
+                assert!(!tree.search(13));
+                assert!(!tree.search(14));
+                assert!(tree.search(15));
+                assert!(!tree.search(16));
+            }
+        )*
+        }
+    }
+
+    test_search! {
+        children_2: 2,
+        children_3: 3,
+        children_4: 4,
+        children_5: 5,
+        children_10: 10,
+        children_60: 60,
+        children_101: 101,
+    }
+}

--- a/__sandbox8/binarySearchTree.zig
+++ b/__sandbox8/binarySearchTree.zig
@@ -1,0 +1,284 @@
+const std = @import("std");
+const print = std.debug.print;
+const ArrayList = std.ArrayList;
+const Allocator = std.mem.Allocator;
+const testing = std.testing;
+
+// Returns a binary search tree instance.
+// Arguments:
+//      T: the type of the info(i.e. i32, i16, u32, etc...)
+//      Allocator: This is needed for the struct instance. In most cases, feel free
+//                 to use std.heap.GeneralPurposeAllocator.
+pub fn BinarySearchTree(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        // This is the node struct. It holds:
+        // info: T
+        // right: A pointer to the right child
+        // left: A pointer to the left child
+        pub const node = struct {
+            info: T,
+            right: ?*node = null,
+            left: ?*node = null,
+        };
+
+        allocator: *Allocator,
+        root: ?*node = null,
+        size: usize = 0,
+
+        // Function to insert elements into the tree
+        // Runs in θ(logn)/O(n), uses the helper _insert private function
+        // Arguments:
+        //      key: T - the key to be inserted into the tree
+        pub fn insert(self: *Self, key: T) !void {
+            self.root = try self._insert(self.root, key);
+            self.size += 1;
+        }
+
+        // Function to remove elements from the tree
+        // Runs in θ(logn)/O(n), uses the helper _remove private function
+        // Arguments:
+        //      key: T - the key to be removed from the tree
+        pub fn remove(self: *Self, key: T) !void {
+            if (self.root == null) {
+                return;
+            }
+            self.root = try self._remove(self.root, key);
+            self.size -= 1;
+        }
+
+        // Function to search if a key exists in the tree
+        // Runs in θ(logn)/O(n), uses the helper _search private function
+        // Arguments:
+        //      key: T - the key that will be searched
+        pub fn search(self: *Self, key: T) bool {
+            return _search(self.root, key);
+        }
+
+        // Function that performs inorder traversal of the tree
+        pub fn inorder(self: *Self, allocator: Allocator, path: *ArrayList(T)) !void {
+            if (self.root == null) {
+                return;
+            }
+            try self._inorder(allocator, self.root, path);
+        }
+
+        // Function that performs preorder traversal of the tree
+        pub fn preorder(self: *Self, allocator: Allocator, path: *ArrayList(T)) !void {
+            if (self.root == null) {
+                return;
+            }
+            try self._preorder(allocator, self.root, path);
+        }
+
+        // Function that performs postorder traversal of the tree
+        pub fn postorder(self: *Self, allocator: Allocator, path: *ArrayList(T)) !void {
+            if (self.root == null) {
+                return;
+            }
+            try self._postorder(allocator, self.root, path);
+        }
+
+        // Function that destroys the allocated memory of the whole tree
+        // Uses the _destroy helper private function
+        pub fn destroy(self: *Self) void {
+            if (self.root == null) {
+                return;
+            }
+            self._destroy(self.root);
+            self.size = 0;
+        }
+
+        // Function that generates a new node
+        // Arguments:
+        //      key: T - The info of the node
+        fn new_node(self: *Self, key: T) !?*node {
+            const nn = try self.allocator.create(node);
+            nn.* = node{ .info = key, .right = null, .left = null };
+            return nn;
+        }
+
+        fn _insert(self: *Self, root: ?*node, key: T) !?*node {
+            if (root == null) {
+                return try self.new_node(key);
+            } else {
+                if (root.?.info < key) {
+                    root.?.right = try self._insert(root.?.right, key);
+                } else {
+                    root.?.left = try self._insert(root.?.left, key);
+                }
+            }
+
+            return root;
+        }
+
+        fn _remove(self: *Self, root: ?*node, key: T) !?*node {
+            if (root == null) {
+                return root;
+            }
+
+            if (root.?.info < key) {
+                root.?.right = try self._remove(root.?.right, key);
+            } else if (root.?.info > key) {
+                root.?.left = try self._remove(root.?.left, key);
+            } else {
+                if (root.?.left == null and root.?.right == null) {
+                    self.allocator.destroy(root.?);
+                    return null;
+                } else if (root.?.left == null) {
+                    const temp = root.?.right;
+                    self.allocator.destroy(root.?);
+                    return temp;
+                } else if (root.?.right == null) {
+                    const temp = root.?.left;
+                    self.allocator.destroy(root.?);
+                    return temp;
+                } else {
+                    var curr: ?*node = root.?.right;
+                    while (curr.?.left != null) : (curr = curr.?.left) {}
+                    root.?.info = curr.?.info;
+                    root.?.right = try self._remove(root.?.right, curr.?.info);
+                }
+            }
+
+            return root;
+        }
+
+        fn _search(root: ?*node, key: T) bool {
+            var head: ?*node = root;
+            while (head) |curr| {
+                if (curr.info < key) {
+                    head = curr.right;
+                } else if (curr.info > key) {
+                    head = curr.left;
+                } else {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        fn _inorder(self: *Self, allocator: Allocator, root: ?*node, path: *ArrayList(T)) !void {
+            if (root != null) {
+                try self._inorder(allocator, root.?.left, path);
+                try path.append(allocator, root.?.info);
+                try self._inorder(allocator, root.?.right, path);
+            }
+        }
+
+        fn _preorder(self: *Self, allocator: Allocator, root: ?*node, path: *ArrayList(T)) !void {
+            if (root != null) {
+                try path.append(allocator, root.?.info);
+                try self._preorder(allocator, root.?.left, path);
+                try self._preorder(allocator, root.?.right, path);
+            }
+        }
+
+        fn _postorder(self: *Self, allocator: Allocator, root: ?*node, path: *ArrayList(T)) !void {
+            if (root != null) {
+                try self._postorder(allocator, root.?.left, path);
+                try self._postorder(allocator, root.?.right, path);
+                try path.append(allocator, root.?.info);
+            }
+        }
+
+        fn _destroy(self: *Self, root: ?*node) void {
+            if (root != null) {
+                self._destroy(root.?.left);
+                self._destroy(root.?.right);
+                self.allocator.destroy(root.?);
+            }
+        }
+    };
+}
+
+test "Testing insertion" {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    var allocator = gpa.allocator();
+
+    var t = BinarySearchTree(i32){ .allocator = &allocator };
+    defer t.destroy();
+
+    try t.insert(10);
+    try t.insert(5);
+    try t.insert(25);
+    try t.insert(3);
+    try t.insert(12);
+    try testing.expect(t.size == 5);
+    try testing.expect(t.search(10) == true);
+    try testing.expect(t.search(15) == false);
+}
+
+test "Testing bst removal" {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    var allocator = gpa.allocator();
+
+    var t = BinarySearchTree(i32){ .allocator = &allocator };
+    defer t.destroy();
+
+    try t.insert(10);
+    try t.insert(5);
+    try t.insert(3);
+    try t.insert(15);
+    try testing.expect(t.size == 4);
+    try testing.expect(t.search(15) == true);
+    try t.remove(10);
+    try testing.expect(t.size == 3);
+    try testing.expect(t.search(10) == false);
+}
+
+test "Testing traversal methods" {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    var allocator = gpa.allocator();
+
+    var t = BinarySearchTree(i32){ .allocator = &allocator };
+    defer t.destroy();
+
+    try t.insert(5);
+    try t.insert(25);
+    try t.insert(3);
+    try t.insert(12);
+    try t.insert(15);
+
+    var ino: ArrayList(i32) = .empty;
+    defer ino.deinit(allocator);
+
+    const check_ino = [_]i32{ 3, 5, 12, 15, 25 };
+    try t.inorder(allocator, &ino);
+    try testing.expect(std.mem.eql(i32, ino.items, &check_ino));
+
+    var pre: ArrayList(i32) = .empty;
+    defer pre.deinit(allocator);
+
+    const check_pre = [_]i32{ 5, 3, 25, 12, 15 };
+    try t.preorder(allocator, &pre);
+
+    try testing.expect(std.mem.eql(i32, pre.items, &check_pre));
+
+    var post: ArrayList(i32) = .empty;
+    defer post.deinit(allocator);
+
+    const check_post = [_]i32{ 3, 15, 12, 25, 5 };
+    try t.postorder(allocator, &post);
+
+    try testing.expect(std.mem.eql(i32, post.items, &check_post));
+}
+
+test "Testing operations on empty trees" {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    var allocator = gpa.allocator();
+
+    var t = BinarySearchTree(i32){ .allocator = &allocator };
+    defer t.destroy();
+
+    try testing.expect(t.size == 0);
+    try testing.expect(t.search(10) == false);
+    try t.remove(10);
+    try testing.expect(t.search(10) == false);
+}

--- a/__sandbox8/fibonacci.f90
+++ b/__sandbox8/fibonacci.f90
@@ -1,0 +1,15 @@
+!> Example program to use the Fibonacci module
+!> Prints the nth Fibonacci number using both recursive and iterative implementations.
+
+program example_fibonacci
+    use fibonacci_module
+    implicit none
+    integer :: n
+
+    n = 7
+
+    print *, 'The Fibonacci number for the position', n, ' is:'
+    print *, 'Recursive solution: ', fib_rec(n)
+    print *, 'Iterative solution: ', fib_itr(n)
+
+end program example_fibonacci

--- a/__sandbox8/resonant_frequency.py
+++ b/__sandbox8/resonant_frequency.py
@@ -1,0 +1,50 @@
+# https://en.wikipedia.org/wiki/LC_circuit
+
+"""An LC circuit, also called a resonant circuit, tank circuit, or tuned circuit,
+is an electric circuit consisting of an inductor, represented by the letter L,
+and a capacitor, represented by the letter C, connected together.
+The circuit can act as an electrical resonator, an electrical analogue of a
+tuning fork, storing energy oscillating at the circuit's resonant frequency.
+Source: https://en.wikipedia.org/wiki/LC_circuit
+"""
+
+from __future__ import annotations
+
+from math import pi, sqrt
+
+
+def resonant_frequency(inductance: float, capacitance: float) -> tuple:
+    """
+    This function can calculate the resonant frequency of LC circuit,
+    for the given value of inductance and capacitnace.
+
+    Examples are given below:
+    >>> resonant_frequency(inductance=10, capacitance=5)
+    ('Resonant frequency', 0.022507907903927652)
+    >>> resonant_frequency(inductance=0, capacitance=5)
+    Traceback (most recent call last):
+      ...
+    ValueError: Inductance cannot be 0 or negative
+    >>> resonant_frequency(inductance=10, capacitance=0)
+    Traceback (most recent call last):
+      ...
+    ValueError: Capacitance cannot be 0 or negative
+    """
+
+    if inductance <= 0:
+        raise ValueError("Inductance cannot be 0 or negative")
+
+    elif capacitance <= 0:
+        raise ValueError("Capacitance cannot be 0 or negative")
+
+    else:
+        return (
+            "Resonant frequency",
+            float(1 / (2 * pi * (sqrt(inductance * capacitance)))),
+        )
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
121 This change cleans up redundant warnings that were emitted from multiple layers. The messages are now centralized and emitted once. This improves log clarity.